### PR TITLE
feat!: publish only esm output

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,16 +7,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "rslib",
     "dev": "rslib -w",

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -1,8 +1,5 @@
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [
-    { syntax: 'es2021', dts: true },
-    { format: 'cjs', syntax: 'es2021' },
-  ],
+  lib: [{ format: 'esm', syntax: 'es2021', dts: true }],
 });


### PR DESCRIPTION
## Summary

- Only build and publish the ESM bundle plus declaration files.
- Remove CJS-specific package entry fields so the published metadata matches the generated output.
- Validate the change with `pnpm lint` and `pnpm build`.

## Related Links

- None