### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "rsbuild-plugin-ejs",
   "version": "2.0.1",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-ejs",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-ejs#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-ejs/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add the package homepage pointing to the repository README
- add the package bugs URL pointing to the repository issues page

## Why
The published npm metadata currently exposes the repository and license, but does not include `homepage` or `bugs` fields. Adding these fields makes the package support links easier to discover from npm and other package tooling.

Current npm metadata checked with:

```bash
npm view rsbuild-plugin-ejs@latest name version repository homepage bugs license --json
```

```json
{
  "name": "rsbuild-plugin-ejs",
  "version": "2.0.1",
  "repository": "https://github.com/rstackjs/rsbuild-plugin-ejs",
  "license": "MIT"
}
```

## Validation
- `node -e "const p=require('./package.json'); if(p.homepage !== 'https://github.com/rstackjs/rsbuild-plugin-ejs#readme') throw new Error('bad homepage'); if(!p.bugs || p.bugs.url !== 'https://github.com/rstackjs/rsbuild-plugin-ejs/issues') throw new Error('bad bugs url'); console.log(JSON.stringify({homepage:p.homepage, bugs:p.bugs}, null, 2));"`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`